### PR TITLE
rhel85: Compress payload image in installer-iso

### DIFF
--- a/internal/distro/distro.go
+++ b/internal/distro/distro.go
@@ -117,6 +117,7 @@ type ImageOptions struct {
 	OSTree       OSTreeImageOptions
 	Size         uint64
 	Subscription *SubscriptionImageOptions
+	TarInstaller *TarInstallerImageOptions
 }
 
 // The OSTreeImageOptions specify ostree-specific image options
@@ -135,6 +136,12 @@ type SubscriptionImageOptions struct {
 	ServerUrl     string
 	BaseUrl       string
 	Insights      bool
+}
+
+// The TarInstallerImageOptions specify tar-installer-specific image options
+// ImageFileName influences the kind of compression done in the tar stage.
+type TarInstallerImageOptions struct {
+	ImageFileName string
 }
 
 type BasePartitionTableMap map[string]disk.PartitionTable

--- a/internal/distro/rhel85/pipelines.go
+++ b/internal/distro/rhel85/pipelines.go
@@ -521,7 +521,7 @@ func tarInstallerPipelines(t *imageType, customizations *blueprint.Customization
 	}
 	kernelVer := fmt.Sprintf("%s-%s.%s", kernelPkg.Version, kernelPkg.Release, kernelPkg.Arch)
 
-	tarPath := "/liveimg.tar"
+	tarPath := "/liveimg.tar.xz"
 	tarPayloadStages := []*osbuild.Stage{tarStage("os", tarPath)}
 	kickstartOptions := tarKickstartStageOptions(makeISORootPath(tarPath))
 	pipelines = append(pipelines, *anacondaTreePipeline(repos, installerPackages, kernelVer, t.Arch().Name()))


### PR DESCRIPTION
Installing *tar.xz images is supported by anaconda, and documented


This pull request includes:

- [ ] adequate testing for the new functionality or fixed issue
- [ ] adequate documentation informing people about the change such as
  - [ ] submit a PR for the [guides](https://github.com/osbuild/guides) repository if this PR changed any behavior described there: https://www.osbuild.org/guides/

<!--
Thanks for proposing a change to osbuild-composer!

Please don't remove the above check list. These are things that each pull
request must have before it is merged. It helps maintainers to not forget
anything.

If the reason for ticking any of the boxes is ambiguous, please add a short
note explaining why.

In addition, if this pull request fixes a downstream issue, please refer to
test/README.md and add these additional items:

- [ ] 1st commit of any `rhbz#` related PR contains bug reproducer; CI reports FAIL or
- [ ] PR contains automated tests for new functionality and
- [ ] QE has approved reproducer/new tests and
- [ ] Subsequent commits provide bug fixes without modifying the reproducer; CI reports PASS and
- [ ] QE approves this PR; RHBZ status is set to `MODIFIED + Verified=Tested`
-->
